### PR TITLE
fix: force Next.js framework on Vercel (resolve 'No Output Directory dist')

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Problem
Vercel build fails at the end with:
> Error: No Output Directory named "dist" found after the Build completed.

The build itself **compiles and type-checks fine** — Vercel is just still expecting a `dist/` output directory (a leftover preset from when this was a Vite project). Next.js outputs to `.next`, which Vercel handles automatically when the framework is detected as Next.js.

## Fix
Add `vercel.json` pinning `"framework": "nextjs"`, so Vercel uses the Next.js build output instead of looking for `dist`.

```json
{
  "framework": "nextjs"
}
```

## Note
If the Vercel **dashboard** still has an explicit *Output Directory* override set to `dist` (Settings → Build & Deployment), clear that toggle too — `vercel.json` should take precedence, but clearing the stale override removes any ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)