### PR TITLE
Redesign: editorial/Swiss layout with green accent

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -55,7 +55,7 @@
     "skillsLabel": "Tools I work with"
   },
   "portfolio": {
-    "heading": "Portfolio",
+    "heading": "Selected Work",
     "subtitle": "A selection of projects I would like to showcase.",
     "labels": {
       "technologies": "Technologies",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -55,7 +55,7 @@
     "skillsLabel": "Kullandığım teknolojiler"
   },
   "portfolio": {
-    "heading": "Portföy",
+    "heading": "Seçili Çalışmalar",
     "subtitle": "Sergilemek istediğim seçilmiş projelerden bazıları.",
     "labels": {
       "technologies": "Teknolojiler",

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -40,7 +40,7 @@ export default function OGImage() {
             width: '500px',
             height: '500px',
             borderRadius: '50%',
-            background: 'rgba(52, 211, 153, 0.12)',
+            background: 'rgba(52, 211, 153, 0.14)',
             filter: 'blur(120px)',
           }}
         />

--- a/src/components/common/section-header.tsx
+++ b/src/components/common/section-header.tsx
@@ -5,32 +5,44 @@ import {gsap, SplitText, useGSAP} from '@/lib/gsap';
 import {cn} from '@/lib/utils';
 
 export function SectionHeader({
+  index,
   title,
+  description,
   className,
 }: {
+  index?: string;
   title: string;
+  description?: string;
   className?: string;
 }) {
-  const ref = useRef<HTMLHeadingElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useGSAP(
     () => {
-      const el = ref.current!;
+      const root = ref.current!;
+      const h = root.querySelector('h2')!;
       const mm = gsap.matchMedia();
       mm.add('(prefers-reduced-motion: no-preference)', () => {
-        const split = new SplitText(el, {type: 'words'});
-        gsap.from(split.words, {
-          yPercent: 110,
-          opacity: 0,
-          duration: 0.6,
-          ease: 'power3.out',
-          stagger: 0.08,
-          scrollTrigger: {
-            trigger: el,
-            start: 'top 85%',
-            once: true,
-          },
+        const split = new SplitText(h, {type: 'words'});
+        const tl = gsap.timeline({
+          scrollTrigger: {trigger: root, start: 'top 85%', once: true},
         });
+        tl.from(root.querySelector('.sh-rule'), {
+          scaleX: 0,
+          transformOrigin: 'left',
+          duration: 0.7,
+          ease: 'power3.inOut',
+        })
+          .from(
+            split.words,
+            {yPercent: 110, opacity: 0, duration: 0.6, ease: 'power3.out', stagger: 0.08},
+            0.15,
+          )
+          .from(
+            root.querySelector('.sh-index'),
+            {opacity: 0, duration: 0.4},
+            0.2,
+          );
         return () => split.revert();
       });
       return () => mm.revert();
@@ -39,14 +51,23 @@ export function SectionHeader({
   );
 
   return (
-    <h2
-      ref={ref}
-      className={cn(
-        'mb-10 overflow-hidden text-3xl font-bold tracking-tight md:text-4xl',
-        className,
+    <div ref={ref} className={cn('mb-12 md:mb-16', className)}>
+      <div className="sh-rule h-px w-full bg-foreground" />
+      <div className="mt-4 flex items-baseline gap-4 md:gap-6">
+        {index && (
+          <span className="sh-index font-mono text-sm font-medium text-primary tnum">
+            {index}
+          </span>
+        )}
+        <h2 className="overflow-hidden text-balance text-4xl font-bold tracking-tighter md:text-6xl">
+          {title}
+        </h2>
+      </div>
+      {description && (
+        <p className="mt-5 max-w-[52ch] text-base leading-relaxed text-muted-foreground md:ml-[calc(1.75rem+1.5rem)]">
+          {description}
+        </p>
       )}
-    >
-      {title}
-    </h2>
+    </div>
   );
 }

--- a/src/components/sections/about.tsx
+++ b/src/components/sections/about.tsx
@@ -18,40 +18,45 @@ export function About() {
 
   return (
     <Section id={SECTION_IDS.about}>
-      <SectionHeader title={t('heading')} />
-      <div className="grid gap-12 md:grid-cols-2">
+      <SectionHeader index="01" title={t('heading')} />
+      <div className="grid gap-12 lg:grid-cols-[1.15fr_0.85fr] lg:gap-16">
         <Reveal variant="slideRight">
-          <h3 className="text-xl font-semibold tracking-tight">{t('whoAmI')}</h3>
-          <p className="mt-4 max-w-[60ch] leading-relaxed text-muted-foreground">{t('bodyA')}</p>
-          <p className="mt-4 max-w-[60ch] leading-relaxed text-muted-foreground">{t('bodyB')}</p>
-          <div className="mt-6">
+          <h3 className="max-w-[18ch] text-2xl font-semibold tracking-tight md:text-3xl">
+            {t('whoAmI')}
+          </h3>
+          <p className="mt-6 max-w-[58ch] leading-relaxed text-muted-foreground">{t('bodyA')}</p>
+          <p className="mt-4 max-w-[58ch] leading-relaxed text-muted-foreground">{t('bodyB')}</p>
+          <div className="mt-8">
             <DownloadResumeButton />
           </div>
         </Reveal>
 
         <Reveal variant="slideLeft">
-          <dl className="divide-y divide-border">
+          <dl>
             {facts.map((f) => (
-              <div key={f.label} className="flex items-center justify-between py-3">
-                <dt className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+              <div
+                key={f.label}
+                className="flex items-center justify-between border-t border-border py-4 first:border-t-0 md:first:border-t"
+              >
+                <dt className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
                   {f.label}
                 </dt>
-                <dd className="text-sm">{f.value}</dd>
+                <dd className="text-sm font-medium">{f.value}</dd>
               </div>
             ))}
           </dl>
-          <div className="mt-8 flex gap-10">
-            <div>
-              <div className="font-mono text-3xl font-bold text-primary">
+          <div className="mt-10 grid grid-cols-2 gap-px overflow-hidden border border-border bg-border">
+            <div className="bg-background p-6">
+              <div className="font-mono text-4xl font-bold tracking-tight text-primary tnum">
                 <Counter value={EXPERIENCE_YEARS} suffix="+" />
               </div>
-              <div className="mt-1 text-xs text-muted-foreground">{t('stats.experienceText')}</div>
+              <div className="mt-2 text-xs text-muted-foreground">{t('stats.experienceText')}</div>
             </div>
-            <div className="border-l border-border pl-10">
-              <div className="font-mono text-3xl font-bold text-primary">
+            <div className="bg-background p-6">
+              <div className="font-mono text-4xl font-bold tracking-tight text-primary tnum">
                 <Counter value={Number(t('stats.projectsNumber'))} suffix="+" />
               </div>
-              <div className="mt-1 text-xs text-muted-foreground">{t('stats.projectsLabel')}</div>
+              <div className="mt-2 text-xs text-muted-foreground">{t('stats.projectsLabel')}</div>
             </div>
           </div>
         </Reveal>

--- a/src/components/sections/contact.tsx
+++ b/src/components/sections/contact.tsx
@@ -7,6 +7,7 @@ import emailjs from '@emailjs/browser';
 import {toast} from 'sonner';
 import {SiGithub, SiX} from '@icons-pack/react-simple-icons';
 import {Section} from '@/components/common/section';
+import {SectionHeader} from '@/components/common/section-header';
 import {Reveal} from '@/components/common/reveal';
 import {Button} from '@/components/ui/button';
 import {Input} from '@/components/ui/input';
@@ -70,27 +71,32 @@ export function Contact() {
 
   return (
     <Section id={SECTION_IDS.contact}>
-      <div className="grid gap-12 md:grid-cols-2 md:items-start">
+      <SectionHeader index="04" title={t('heading')} description={t('pitch')} />
+
+      <div className="grid gap-12 lg:grid-cols-2 lg:gap-16">
         <Reveal variant="slideRight">
-          <h2 className="text-3xl font-bold tracking-tight md:text-4xl">{t('heading')}</h2>
-          <p className="mt-6 max-w-[42ch] text-muted-foreground">{t('pitch')}</p>
           <a
             href={`mailto:${EMAIL}`}
-            className="mt-5 inline-block font-mono text-primary underline-offset-4 hover:underline"
+            className="group block w-fit text-balance text-3xl font-semibold tracking-tighter md:text-5xl"
           >
-            {EMAIL}
+            <span className="bg-[length:100%_1px] bg-bottom bg-no-repeat pb-1 [background-image:linear-gradient(var(--color-primary),var(--color-primary))] [background-size:0%_1px] transition-[background-size] duration-300 group-hover:[background-size:100%_1px]">
+              {EMAIL}
+            </span>
           </a>
-          <div className="mt-6">
-            <p className="mb-3 font-mono text-xs uppercase tracking-wider text-muted-foreground">{t('followMe')}</p>
-            <div className="flex gap-3">
+
+          <div className="mt-12">
+            <p className="mb-4 font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+              {t('followMe')}
+            </p>
+            <div className="flex flex-wrap gap-3">
               <Social href={SOCIAL_LINKS.github} label="GitHub">
-                <SiGithub className="size-[1.1rem]" />
+                <SiGithub className="size-[1.1rem]" /> GitHub
               </Social>
               <Social href={SOCIAL_LINKS.linkedin} label="LinkedIn">
-                <SiLinkedin className="size-[1.1rem]" />
+                <SiLinkedin className="size-[1.1rem]" /> LinkedIn
               </Social>
               <Social href={SOCIAL_LINKS.x} label="X">
-                <SiX className="size-[1.1rem]" />
+                <SiX className="size-[1.1rem]" /> X
               </Social>
             </div>
           </div>
@@ -100,7 +106,7 @@ export function Contact() {
           <form
             id="contact-form"
             onSubmit={handleSubmit(onSubmit)}
-            className="flex max-w-md flex-col gap-5"
+            className="flex flex-col gap-5"
             noValidate
           >
             <div className="flex flex-col gap-2">
@@ -135,7 +141,7 @@ function Social({href, label, children}: {href: string; label: string; children:
       target="_blank"
       rel="noreferrer"
       aria-label={label}
-      className="grid size-10 place-items-center rounded-lg border border-border text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground"
+      className="inline-flex items-center gap-2 border border-border px-4 py-2.5 text-sm text-muted-foreground transition-colors hover:border-primary/60 hover:bg-secondary/50 hover:text-foreground"
     >
       {children}
     </a>

--- a/src/components/sections/footer.tsx
+++ b/src/components/sections/footer.tsx
@@ -1,13 +1,84 @@
 import {useTranslations} from 'next-intl';
-import {CURRENT_YEAR} from '@/lib/site';
+import {ArrowUp} from 'lucide-react';
+import {CURRENT_YEAR, SECTION_IDS, SOCIAL_LINKS, EMAIL} from '@/lib/site';
 
 export function Footer() {
   const t = useTranslations();
+
+  const nav = [
+    {id: SECTION_IDS.about, key: 'about'},
+    {id: SECTION_IDS.resume, key: 'resume'},
+    {id: SECTION_IDS.portfolio, key: 'portfolio'},
+    {id: SECTION_IDS.contact, key: 'contact'},
+  ] as const;
+
+  const socials = [
+    {href: SOCIAL_LINKS.github, label: 'GitHub'},
+    {href: SOCIAL_LINKS.linkedin, label: 'LinkedIn'},
+    {href: SOCIAL_LINKS.x, label: 'X'},
+  ];
+
   return (
-    <footer className="border-t border-border py-8">
-      <p className="text-center font-mono text-xs text-muted-foreground">
-        {t('footer.copyrightLabel')} © {CURRENT_YEAR} {t('header.name')}. {t('footer.copyright')}
-      </p>
+    <footer className="border-t border-foreground">
+      <div className="mx-auto max-w-6xl px-5 py-14 md:px-8">
+        <div className="grid gap-10 md:grid-cols-[1fr_auto] md:items-start">
+          <div>
+            <a
+              href={`#${SECTION_IDS.home}`}
+              className="text-4xl font-bold tracking-tighter md:text-6xl"
+            >
+              {t('header.name')}
+              <span className="text-primary">.</span>
+            </a>
+            <a
+              href={`mailto:${EMAIL}`}
+              className="mt-4 block w-fit font-mono text-sm text-muted-foreground transition-colors hover:text-primary"
+            >
+              {EMAIL}
+            </a>
+          </div>
+
+          <div className="flex gap-12">
+            <nav className="flex flex-col gap-2.5">
+              {nav.map((item) => (
+                <a
+                  key={item.id}
+                  href={`#${item.id}`}
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {t(`header.menu.${item.key}`)}
+                </a>
+              ))}
+            </nav>
+            <div className="flex flex-col gap-2.5">
+              {socials.map((s) => (
+                <a
+                  key={s.label}
+                  href={s.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {s.label}
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-14 flex flex-col gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <p className="font-mono text-xs text-muted-foreground">
+            © {CURRENT_YEAR} {t('header.name')}. {t('footer.copyright')}
+          </p>
+          <a
+            href={`#${SECTION_IDS.home}`}
+            className="group inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowUp strokeWidth={1.75} className="size-3.5 transition-transform group-hover:-translate-y-0.5" />
+            Top
+          </a>
+        </div>
+      </div>
     </footer>
   );
 }

--- a/src/components/sections/header.tsx
+++ b/src/components/sections/header.tsx
@@ -11,11 +11,11 @@ import {LanguageSwitcher} from '@/components/common/language-switcher';
 import {SECTION_IDS} from '@/lib/site';
 
 const NAV = [
-  {id: SECTION_IDS.home, key: 'home'},
-  {id: SECTION_IDS.about, key: 'about'},
-  {id: SECTION_IDS.resume, key: 'resume'},
-  {id: SECTION_IDS.portfolio, key: 'portfolio'},
-  {id: SECTION_IDS.contact, key: 'contact'},
+  {id: SECTION_IDS.home, key: 'home', n: '00'},
+  {id: SECTION_IDS.about, key: 'about', n: '01'},
+  {id: SECTION_IDS.resume, key: 'resume', n: '02'},
+  {id: SECTION_IDS.portfolio, key: 'portfolio', n: '03'},
+  {id: SECTION_IDS.contact, key: 'contact', n: '04'},
 ] as const;
 
 export function Header() {
@@ -50,21 +50,32 @@ export function Header() {
   });
 
   return (
-    <header ref={headerRef} className="sticky top-0 z-50 border-b border-border/0 bg-background/70 backdrop-blur-md transition-colors data-[scrolled=true]:border-border">
+    <header
+      ref={headerRef}
+      className="sticky top-0 z-50 border-b border-transparent bg-background/80 backdrop-blur-md transition-colors duration-300 data-[scrolled=true]:border-border"
+    >
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-5 md:px-8">
-        <a href={`#${SECTION_IDS.home}`} className="font-mono text-sm font-semibold">
-          <span className="text-primary">●</span> {t('name')}
+        <a
+          href={`#${SECTION_IDS.home}`}
+          className="group flex items-center gap-2.5 text-sm font-semibold tracking-tight"
+        >
+          <span className="size-2.5 bg-primary transition-transform duration-300 group-hover:rotate-45" />
+          {t('name')}
         </a>
 
-        <nav className="hidden items-center gap-1 md:flex">
+        <nav className="hidden items-center gap-7 md:flex">
           {NAV.map((item) => (
             <a
               key={item.id}
               href={`#${item.id}`}
               data-active={activeId === item.id}
-              className="relative px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground data-[active=true]:text-foreground after:pointer-events-none after:absolute after:bottom-1 after:left-3 after:right-3 after:h-px after:origin-left after:scale-x-0 after:bg-primary after:transition-transform after:duration-300 hover:after:scale-x-100 data-[active=true]:after:scale-x-100"
+              className="group relative flex items-center gap-1.5 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground data-[active=true]:text-foreground"
             >
+              <span className="font-mono text-[10px] text-muted-foreground/60 tnum transition-colors group-hover:text-primary group-data-[active=true]:text-primary">
+                {item.n}
+              </span>
               {t(`menu.${item.key}`)}
+              <span className="pointer-events-none absolute -bottom-0.5 left-0 h-px w-full origin-left scale-x-0 bg-primary transition-transform duration-300 group-hover:scale-x-100 group-data-[active=true]:scale-x-100" />
             </a>
           ))}
         </nav>
@@ -78,21 +89,23 @@ export function Header() {
                 <Menu strokeWidth={1.75} />
               </Button>
             </SheetTrigger>
-            <SheetContent side="right" className="w-64">
-              <SheetTitle className="font-mono text-sm font-semibold text-primary">
-                <span className="text-primary">●</span> {t('name')}
+            <SheetContent side="right" className="w-72">
+              <SheetTitle className="flex items-center gap-2.5 text-sm font-semibold tracking-tight">
+                <span className="size-2.5 bg-primary" />
+                {t('name')}
               </SheetTitle>
               <SheetDescription className="sr-only">
                 {ta11y('siteNavigation')}
               </SheetDescription>
-              <nav className="mt-2 flex flex-col gap-0.5">
+              <nav className="mt-4 flex flex-col">
                 {NAV.map((item) => (
                   <a
                     key={item.id}
                     href={`#${item.id}`}
                     onClick={() => setOpen(false)}
-                    className="rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    className="flex items-baseline gap-3 border-t border-border py-4 text-lg font-medium tracking-tight transition-colors last:border-b hover:text-primary"
                   >
+                    <span className="font-mono text-xs text-muted-foreground tnum">{item.n}</span>
                     {t(`menu.${item.key}`)}
                   </a>
                 ))}

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -3,11 +3,10 @@
 import {useRef} from 'react';
 import Image from 'next/image';
 import {useTranslations} from 'next-intl';
-import {MapPin, ArrowRight} from 'lucide-react';
+import {ArrowDownRight} from 'lucide-react';
 import {gsap, SplitText, useGSAP} from '@/lib/gsap';
 import {useMagnetic} from '@/lib/animation/use-magnetic';
 import {Button} from '@/components/ui/button';
-import {Badge} from '@/components/ui/badge';
 import {DownloadResumeButton} from '@/components/common/download-resume-button';
 import {SECTION_IDS} from '@/lib/site';
 import me from '@/assets/me.png';
@@ -18,28 +17,30 @@ export function Hero() {
   const contactCtaRef = useMagnetic<HTMLAnchorElement>();
   const resumeCtaRef = useMagnetic<HTMLAnchorElement>();
 
+  const [first, ...rest] = t('name').split(' ');
+  const last = rest.join(' ');
+
   useGSAP(
     () => {
       const mm = gsap.matchMedia();
       mm.add('(prefers-reduced-motion: no-preference)', () => {
         const split = new SplitText('.hero-name', {type: 'chars'});
         const tl = gsap.timeline({defaults: {ease: 'power3.out'}});
-        tl.from(split.chars, {yPercent: 110, opacity: 0, duration: 0.8, stagger: 0.025})
-          .from('.hero-eyebrow', {opacity: 0, y: 10, duration: 0.5}, 0.1)
-          .from('.hero-fade', {opacity: 0, y: 16, duration: 0.6, stagger: 0.08}, 0.4)
-          .from('.hero-portrait', {opacity: 0, scale: 0.94, duration: 0.8}, 0.2);
+        tl.from('.hero-topbar', {opacity: 0, y: -12, duration: 0.5})
+          .from(split.chars, {yPercent: 115, duration: 0.9, stagger: 0.022}, 0.1)
+          .from('.hero-fade', {opacity: 0, y: 18, duration: 0.6, stagger: 0.08}, 0.5)
+          .from('.hero-portrait', {opacity: 0, scale: 0.96, duration: 0.9}, 0.3);
         return () => split.revert();
       });
       mm.add('(min-width: 768px) and (prefers-reduced-motion: no-preference)', () => {
-        gsap.set('.hero-glow', {xPercent: -50});
         const st = {
           trigger: ref.current!,
           start: 'top top',
           end: 'bottom top',
           scrub: 1,
         } as const;
-        gsap.to('.hero-dotgrid', {yPercent: 12, ease: 'none', scrollTrigger: st});
-        gsap.to('.hero-glow', {yPercent: 30, ease: 'none', scrollTrigger: st});
+        gsap.to('.hero-gridbg', {yPercent: 14, ease: 'none', scrollTrigger: st});
+        gsap.to('.hero-portrait', {yPercent: -10, ease: 'none', scrollTrigger: st});
       });
       return () => mm.revert();
     },
@@ -50,47 +51,58 @@ export function Hero() {
     <section
       id={SECTION_IDS.home}
       ref={ref}
-      className="relative flex min-h-[100dvh] items-center overflow-hidden pt-16 pb-12"
+      className="relative flex min-h-[100dvh] flex-col justify-center overflow-hidden pt-24 pb-12"
     >
-      <div className="hero-dotgrid dot-grid pointer-events-none absolute inset-0 text-foreground/[0.12]" />
-      <div className="hero-glow pointer-events-none absolute left-1/4 top-1/3 size-[36rem] rounded-full bg-primary/15 blur-[120px]" />
+      <div className="hero-gridbg grid-lines pointer-events-none absolute inset-0 text-foreground/[0.05] [mask-image:radial-gradient(ellipse_90%_70%_at_50%_30%,#000_50%,transparent_100%)]" />
 
-      <div className="mx-auto grid w-full max-w-6xl items-center gap-12 px-5 md:px-8 lg:grid-cols-[1.2fr_1fr]">
-        <div>
-          <p className="hero-eyebrow mb-5 font-mono text-sm text-primary">{t('prompt')}</p>
-          <h1 className="hero-name overflow-hidden text-5xl font-bold leading-[0.95] tracking-tighter text-balance md:text-7xl">
-            {t('name')}
-          </h1>
-          <p className="hero-fade mt-4 font-mono text-lg text-muted-foreground md:text-xl">
-            {t('role')}
-          </p>
-          <p className="hero-fade mt-5 max-w-[42ch] text-base leading-relaxed text-muted-foreground">
-            {t('tagline')}
-          </p>
-          <div className="hero-fade mt-5">
-            <Badge variant="secondary" className="font-mono">
-              <MapPin className="size-3.5" strokeWidth={1.75} /> {t('location')}
-            </Badge>
+      <div className="mx-auto w-full max-w-6xl px-5 md:px-8">
+        {/* top meta bar */}
+        <div className="hero-topbar mb-10 flex items-center justify-between border-t border-foreground pt-4 font-mono text-xs text-muted-foreground md:mb-14">
+          <span className="text-primary">{t('prompt')}</span>
+          <span className="uppercase tracking-[0.18em]">{t('location')}</span>
+        </div>
+
+        <div className="grid items-end gap-10 lg:grid-cols-[1fr_auto]">
+          {/* giant wordmark */}
+          <div>
+            <p className="hero-fade mb-4 font-mono text-sm uppercase tracking-[0.2em] text-muted-foreground">
+              {t('role')}
+            </p>
+            <h1 className="hero-name overflow-hidden text-[clamp(3.25rem,14vw,11rem)] font-bold uppercase leading-[0.86] tracking-tighter">
+              <span className="block">{first}</span>
+              <span className="block">
+                {last}
+                <span className="text-primary">.</span>
+              </span>
+            </h1>
           </div>
-          <div className="hero-fade mt-7 flex flex-wrap gap-3">
-            <Button asChild size="lg">
-              <a ref={contactCtaRef} href={`#${SECTION_IDS.contact}`}>
-                {t('ctaContact')} <ArrowRight strokeWidth={1.75} />
-              </a>
-            </Button>
-            <DownloadResumeButton anchorRef={resumeCtaRef} />
+
+          {/* portrait */}
+          <div className="hero-portrait order-first w-40 shrink-0 sm:w-48 lg:order-none lg:w-56">
+            <div className="relative overflow-hidden border border-border">
+              <Image
+                src={me}
+                alt={t('name')}
+                priority
+                placeholder="blur"
+                className="aspect-[4/5] w-full object-cover grayscale transition-[filter] duration-500 hover:grayscale-0"
+              />
+            </div>
           </div>
         </div>
 
-        <div className="hero-portrait relative mx-auto w-full max-w-sm md:max-w-md">
-          <div className="overflow-hidden rounded-2xl border border-border ring-1 ring-primary/25 shadow-[0_0_60px_-15px_var(--color-primary)]">
-            <Image
-              src={me}
-              alt="Teoman Kirma"
-              priority
-              placeholder="blur"
-              className="h-auto w-full object-cover"
-            />
+        {/* bottom row */}
+        <div className="mt-10 grid gap-8 border-t border-border pt-8 md:mt-14 md:grid-cols-[1fr_auto] md:items-end">
+          <p className="hero-fade max-w-[46ch] text-lg leading-relaxed text-muted-foreground md:text-xl">
+            {t('tagline')}
+          </p>
+          <div className="hero-fade flex flex-wrap gap-3">
+            <Button asChild size="lg">
+              <a ref={contactCtaRef} href={`#${SECTION_IDS.contact}`}>
+                {t('ctaContact')} <ArrowDownRight strokeWidth={1.75} />
+              </a>
+            </Button>
+            <DownloadResumeButton anchorRef={resumeCtaRef} />
           </div>
         </div>
       </div>

--- a/src/components/sections/portfolio.tsx
+++ b/src/components/sections/portfolio.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import Image from 'next/image';
 import {useTranslations} from 'next-intl';
-import {ExternalLink} from 'lucide-react';
+import {ArrowUpRight, ExternalLink} from 'lucide-react';
 import {gsap, useGSAP} from '@/lib/gsap';
-import {useTilt} from '@/lib/animation/use-tilt';
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription,
 } from '@/components/ui/dialog';
@@ -15,35 +14,25 @@ import {SectionHeader} from '@/components/common/section-header';
 import {PROJECTS} from '@/lib/projects';
 import {SECTION_IDS} from '@/lib/site';
 
+type QuickTo = ReturnType<typeof gsap.quickTo>;
+
 export function Portfolio() {
   const t = useTranslations('portfolio');
   const wrap = useRef<HTMLDivElement>(null);
-  const track = useRef<HTMLDivElement>(null);
+  const preview = useRef<HTMLDivElement>(null);
+  const xTo = useRef<QuickTo | null>(null);
+  const yTo = useRef<QuickTo | null>(null);
+  const [active, setActive] = useState<number | null>(null);
 
   useGSAP(
     () => {
       const mm = gsap.matchMedia();
       mm.add(
-        '(min-width: 768px) and (prefers-reduced-motion: no-preference)',
+        '(min-width: 768px) and (hover: hover) and (prefers-reduced-motion: no-preference)',
         () => {
-          // Use clientWidth (excludes the scrollbar) so the pan reaches the
-          // edge correctly even with always-visible scrollbars. Function-based
-          // values recompute on refresh/resize via invalidateOnRefresh.
-          const getDistance = () =>
-            track.current!.scrollWidth - document.documentElement.clientWidth;
-          if (getDistance() <= 0) return;
-          gsap.to(track.current, {
-            x: () => -getDistance(),
-            ease: 'none',
-            scrollTrigger: {
-              trigger: wrap.current,
-              start: 'top top',
-              end: () => `+=${getDistance()}`,
-              pin: true,
-              scrub: 1,
-              invalidateOnRefresh: true,
-            },
-          });
+          gsap.set(preview.current, {xPercent: -50, yPercent: -50, opacity: 0, scale: 0.85});
+          xTo.current = gsap.quickTo(preview.current, 'x', {duration: 0.55, ease: 'power3'});
+          yTo.current = gsap.quickTo(preview.current, 'y', {duration: 0.55, ease: 'power3'});
         },
       );
       return () => mm.revert();
@@ -51,90 +40,127 @@ export function Portfolio() {
     {scope: wrap},
   );
 
+  function handleMove(e: React.MouseEvent) {
+    xTo.current?.(e.clientX);
+    yTo.current?.(e.clientY);
+  }
+
+  function show(i: number) {
+    setActive(i);
+    gsap.to(preview.current, {opacity: 1, scale: 1, duration: 0.3, ease: 'power3.out'});
+  }
+
+  function hide() {
+    setActive(null);
+    gsap.to(preview.current, {opacity: 0, scale: 0.85, duration: 0.3, ease: 'power3.out'});
+  }
+
   return (
-    <section id={SECTION_IDS.portfolio} ref={wrap} className="relative overflow-hidden py-20 md:py-0">
-      <div className="mx-auto max-w-6xl px-5 pt-0 md:px-8 md:pt-28">
-        <SectionHeader title={t('heading')} />
-        <p className="-mt-6 mb-10 max-w-[55ch] text-muted-foreground">{t('subtitle')}</p>
-      </div>
+    <section id={SECTION_IDS.portfolio} className="scroll-mt-20 py-20 md:py-28">
+      <div ref={wrap} className="mx-auto w-full max-w-6xl px-5 md:px-8">
+        <SectionHeader index="03" title={t('heading')} description={t('subtitle')} />
 
-      <div
-        ref={track}
-        className="flex gap-6 overflow-x-auto px-5 pb-4 [scrollbar-width:none] md:items-center md:overflow-visible md:px-8 md:pb-0"
-        style={{scrollSnapType: 'x mandatory'}}
-      >
-        {PROJECTS.map((p) => (
-          <Dialog key={p.key}>
-            <DialogTrigger asChild>
-              <button className="group block w-[80vw] max-w-sm shrink-0 snap-start text-left md:w-[22rem]">
-                <TiltInner>
-                  <div className="aspect-[16/10] overflow-hidden">
-                    <Image
-                      src={p.image}
-                      alt={p.title}
-                      placeholder="blur"
-                      className="size-full object-cover transition-transform duration-500 group-hover:scale-105"
-                    />
-                  </div>
-                  <div className="p-5">
-                    <h3 className="font-semibold">{p.title}</h3>
-                    <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                      {t(`items.${p.key}.description`)}
-                    </p>
-                    <div className="mt-3 flex flex-wrap gap-1.5">
-                      {p.technologies.split(',').slice(0, 3).map((tech) => (
-                        <Badge key={tech} variant="secondary" className="font-mono text-[11px]">
-                          {tech.trim()}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                </TiltInner>
-              </button>
-            </DialogTrigger>
+        {/* floating cursor preview (desktop, hover devices) */}
+        <div
+          ref={preview}
+          aria-hidden
+          className="pointer-events-none fixed left-0 top-0 z-40 hidden aspect-[16/10] w-[24rem] overflow-hidden border border-border bg-card shadow-2xl will-change-transform md:block"
+        >
+          {active !== null && (
+            <Image
+              key={PROJECTS[active].key}
+              src={PROJECTS[active].image}
+              alt=""
+              placeholder="blur"
+              className="size-full object-cover"
+            />
+          )}
+        </div>
 
-            <DialogContent className="w-[92vw] sm:max-w-3xl md:max-w-4xl max-h-[90vh] overflow-y-auto sm:p-6">
-              <div className="overflow-hidden rounded-lg border border-border">
-                <Image src={p.image} alt={p.title} placeholder="blur" className="h-auto w-full object-cover" />
-              </div>
-              <DialogHeader>
-                <DialogTitle>{p.title}</DialogTitle>
-                <DialogDescription>{t(`items.${p.key}.description`)}</DialogDescription>
-              </DialogHeader>
-              <dl className="space-y-2 text-sm">
-                <Row label={t('labels.technologies')} value={p.technologies} />
-                <Row label={t('labels.industry')} value={t(`items.${p.key}.industry`)} />
-                <Row label={t('labels.date')} value={t(`items.${p.key}.date`)} />
-              </dl>
-              <Button asChild className="mt-2 w-fit">
-                <a href={p.href} target="_blank" rel="noreferrer">
-                  {t(`items.${p.key}.linkLabel`)} <ExternalLink strokeWidth={1.75} />
-                </a>
-              </Button>
-            </DialogContent>
-          </Dialog>
-        ))}
+        <div onMouseMove={handleMove} onMouseLeave={hide}>
+          {PROJECTS.map((p, i) => {
+            const year = t(`items.${p.key}.date`).trim().split(' ').pop();
+            return (
+              <Dialog key={p.key}>
+                <DialogTrigger asChild>
+                  <button
+                    onMouseEnter={() => show(i)}
+                    data-active={active === i}
+                    className="group relative block w-full border-t border-border text-left transition-colors last:border-b data-[active=true]:text-foreground md:data-[active=true]:[&_.row-pad]:px-4"
+                  >
+                    <span className="row-pad grid grid-cols-[auto_1fr_auto] items-center gap-4 py-6 transition-[padding,background-color] duration-300 group-hover:bg-secondary/40 md:gap-8 md:py-7">
+                      <span className="font-mono text-sm text-muted-foreground tnum transition-colors group-hover:text-primary">
+                        {String(i + 1).padStart(2, '0')}
+                      </span>
+
+                      <span className="min-w-0">
+                        <span className="flex items-center gap-2">
+                          <span className="truncate text-2xl font-semibold tracking-tight md:text-3xl">
+                            {p.title}
+                          </span>
+                          <ArrowUpRight
+                            strokeWidth={1.75}
+                            className="size-5 shrink-0 text-muted-foreground opacity-0 -translate-x-1 transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100 group-hover:text-primary"
+                          />
+                        </span>
+                        <span className="mt-2 flex flex-wrap gap-1.5">
+                          {p.technologies.split(',').slice(0, 4).map((tech) => (
+                            <Badge key={tech} variant="secondary" className="font-mono text-[11px] font-normal">
+                              {tech.trim()}
+                            </Badge>
+                          ))}
+                        </span>
+                      </span>
+
+                      <span className="self-start font-mono text-sm text-muted-foreground tnum md:self-center">
+                        {year}
+                      </span>
+                    </span>
+
+                    {/* mobile thumbnail */}
+                    <span className="mb-6 block overflow-hidden border border-border md:hidden">
+                      <Image
+                        src={p.image}
+                        alt={p.title}
+                        placeholder="blur"
+                        className="aspect-[16/10] w-full object-cover"
+                      />
+                    </span>
+                  </button>
+                </DialogTrigger>
+
+                <DialogContent className="max-h-[90vh] w-[92vw] overflow-y-auto sm:max-w-3xl sm:p-6 md:max-w-4xl">
+                  <div className="overflow-hidden border border-border">
+                    <Image src={p.image} alt={p.title} placeholder="blur" className="h-auto w-full object-cover" />
+                  </div>
+                  <DialogHeader>
+                    <DialogTitle className="text-2xl tracking-tight">{p.title}</DialogTitle>
+                    <DialogDescription>{t(`items.${p.key}.description`)}</DialogDescription>
+                  </DialogHeader>
+                  <dl className="text-sm">
+                    <Row label={t('labels.technologies')} value={p.technologies} />
+                    <Row label={t('labels.industry')} value={t(`items.${p.key}.industry`)} />
+                    <Row label={t('labels.date')} value={t(`items.${p.key}.date`)} />
+                  </dl>
+                  <Button asChild className="mt-2 w-fit">
+                    <a href={p.href} target="_blank" rel="noreferrer">
+                      {t(`items.${p.key}.linkLabel`)} <ExternalLink strokeWidth={1.75} />
+                    </a>
+                  </Button>
+                </DialogContent>
+              </Dialog>
+            );
+          })}
+        </div>
       </div>
     </section>
   );
 }
 
-function TiltInner({children}: {children: React.ReactNode}) {
-  const ref = useTilt<HTMLDivElement>({max: 6});
-  return (
-    <div
-      ref={ref}
-      className="overflow-hidden rounded-xl border border-border bg-card transition-[border-color,box-shadow] duration-300 group-hover:border-primary/60"
-    >
-      {children}
-    </div>
-  );
-}
-
 function Row({label, value}: {label: string; value: string}) {
   return (
-    <div className="flex justify-between gap-6 border-b border-border py-2 last:border-0">
-      <dt className="font-mono text-xs uppercase tracking-wider text-muted-foreground">{label}</dt>
+    <div className="flex justify-between gap-6 border-b border-border py-2.5 last:border-0">
+      <dt className="font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">{label}</dt>
       <dd className="text-right">{value}</dd>
     </div>
   );

--- a/src/components/sections/resume.tsx
+++ b/src/components/sections/resume.tsx
@@ -3,8 +3,6 @@ import {useTranslations} from 'next-intl';
 import {Section} from '@/components/common/section';
 import {SectionHeader} from '@/components/common/section-header';
 import {Reveal} from '@/components/common/reveal';
-import {Card, CardContent} from '@/components/ui/card';
-import {Badge} from '@/components/ui/badge';
 import {SkillsMarquee} from '@/components/common/skills-marquee';
 import {SECTION_IDS, GPA} from '@/lib/site';
 import school from '@/assets/nisantasi-university.png';
@@ -13,43 +11,66 @@ import company from '@/assets/bytesandpixels.jpeg';
 export function Resume() {
   const t = useTranslations('resume');
 
-  return (
-    <Section id={SECTION_IDS.resume} className="bg-card/30">
-      <SectionHeader title={t('heading')} />
-      <Reveal stagger={0.12} className="grid gap-6 md:grid-cols-2">
-        <Card>
-          <CardContent className="flex gap-4 p-6">
-            <Image src={school} alt={t('schoolName')} className="size-16 rounded-lg border border-border object-cover" />
-            <div>
-              <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">{t('eduTitle')}</p>
-              <h3 className="mt-1 font-semibold">{t('schoolName')}</h3>
-              <p className="text-sm text-muted-foreground">{t('degree')}</p>
-              <div className="mt-2 flex items-center gap-2">
-                <Badge className="font-mono">{t('eduYears')}</Badge>
-                <span className="text-xs text-muted-foreground">{t('gpaLabel')} {GPA}</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+  const entries = [
+    {
+      kind: t('expTitle'),
+      logo: company,
+      title: t('expRole'),
+      subtitle: t('companyName'),
+      meta: t('expLocation'),
+      dates: t('expDates'),
+      extra: null as string | null,
+    },
+    {
+      kind: t('eduTitle'),
+      logo: school,
+      title: t('schoolName'),
+      subtitle: t('degree'),
+      meta: null,
+      dates: t('eduYears'),
+      extra: `${t('gpaLabel')} ${GPA}`,
+    },
+  ];
 
-        <Card>
-          <CardContent className="flex gap-4 p-6">
-            <Image src={company} alt={t('companyName')} className="size-16 rounded-lg border border-border object-cover" />
-            <div>
-              <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">{t('expTitle')}</p>
-              <h3 className="mt-1 font-semibold">{t('expRole')}</h3>
-              <p className="text-sm text-muted-foreground">{t('companyName')}</p>
-              <p className="text-xs text-muted-foreground">{t('expLocation')}</p>
-              <div className="mt-2">
-                <Badge className="font-mono">{t('expDates')}</Badge>
-              </div>
+  return (
+    <Section id={SECTION_IDS.resume}>
+      <SectionHeader index="02" title={t('heading')} />
+
+      <Reveal stagger={0.12}>
+        {entries.map((e) => (
+          <div
+            key={e.kind}
+            className="group grid grid-cols-[auto_1fr] items-start gap-x-5 gap-y-3 border-t border-border py-8 last:border-b md:grid-cols-[3.5rem_1fr_auto] md:gap-x-8"
+          >
+            <Image
+              src={e.logo}
+              alt={e.subtitle}
+              className="size-12 border border-border object-cover md:size-14"
+            />
+            <div className="min-w-0">
+              <p className="font-mono text-xs uppercase tracking-[0.15em] text-primary">
+                {e.kind}
+              </p>
+              <h3 className="mt-1.5 text-xl font-semibold tracking-tight md:text-2xl">
+                {e.title}
+              </h3>
+              <p className="mt-0.5 text-muted-foreground">{e.subtitle}</p>
+              {e.meta && (
+                <p className="mt-0.5 text-sm text-muted-foreground">{e.meta}</p>
+              )}
             </div>
-          </CardContent>
-        </Card>
+            <div className="col-span-2 flex items-center gap-3 font-mono text-sm text-muted-foreground md:col-span-1 md:flex-col md:items-end md:gap-1 md:text-right">
+              <span className="tnum">{e.dates}</span>
+              {e.extra && <span className="text-foreground">{e.extra}</span>}
+            </div>
+          </div>
+        ))}
       </Reveal>
 
-      <div className="mt-12">
-        <p className="mb-4 font-mono text-xs uppercase tracking-wider text-muted-foreground">{t('skillsLabel')}</p>
+      <div className="mt-14">
+        <p className="mb-5 font-mono text-xs uppercase tracking-[0.15em] text-muted-foreground">
+          {t('skillsLabel')}
+        </p>
         <SkillsMarquee />
       </div>
     </Section>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,45 +4,55 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --radius: 0.75rem;
-  --background: oklch(0.98 0.003 286);
-  --foreground: oklch(0.18 0.006 286);
+  /* Crisp, editorial corners */
+  --radius: 0.25rem;
+
+  /* Swiss / editorial light palette — paper white + ink black */
+  --background: oklch(0.99 0 0);
+  --foreground: oklch(0.15 0.01 264);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.18 0.006 286);
+  --card-foreground: oklch(0.15 0.01 264);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.18 0.006 286);
+  --popover-foreground: oklch(0.15 0.01 264);
+
+  /* Emerald green accent */
   --primary: oklch(0.62 0.17 150);
   --primary-foreground: oklch(0.99 0.01 150);
-  --secondary: oklch(0.96 0.004 286);
-  --secondary-foreground: oklch(0.22 0.006 286);
-  --muted: oklch(0.96 0.004 286);
-  --muted-foreground: oklch(0.5 0.01 286);
-  --accent: oklch(0.96 0.004 286);
-  --accent-foreground: oklch(0.22 0.006 286);
+
+  --secondary: oklch(0.96 0.003 264);
+  --secondary-foreground: oklch(0.22 0.01 264);
+  --muted: oklch(0.96 0.003 264);
+  --muted-foreground: oklch(0.46 0.01 264);
+  --accent: oklch(0.95 0.02 150);
+  --accent-foreground: oklch(0.4 0.13 150);
+
   --destructive: oklch(0.58 0.22 27);
-  --border: oklch(0.91 0.004 286);
-  --input: oklch(0.91 0.004 286);
+  --border: oklch(0.9 0.004 264);
+  --input: oklch(0.9 0.004 264);
   --ring: oklch(0.62 0.17 150);
 }
 
 .dark {
-  --background: oklch(0.16 0.004 286);
-  --foreground: oklch(0.97 0.002 286);
-  --card: oklch(0.19 0.005 286);
-  --card-foreground: oklch(0.97 0.002 286);
-  --popover: oklch(0.19 0.005 286);
-  --popover-foreground: oklch(0.97 0.002 286);
+  --background: oklch(0.14 0.005 264);
+  --foreground: oklch(0.96 0.002 264);
+  --card: oklch(0.17 0.006 264);
+  --card-foreground: oklch(0.96 0.002 264);
+  --popover: oklch(0.17 0.006 264);
+  --popover-foreground: oklch(0.96 0.002 264);
+
   --primary: oklch(0.72 0.19 150);
   --primary-foreground: oklch(0.16 0.04 150);
-  --secondary: oklch(0.24 0.006 286);
-  --secondary-foreground: oklch(0.97 0.002 286);
-  --muted: oklch(0.24 0.006 286);
-  --muted-foreground: oklch(0.65 0.01 286);
-  --accent: oklch(0.26 0.006 286);
-  --accent-foreground: oklch(0.97 0.002 286);
+
+  --secondary: oklch(0.22 0.008 264);
+  --secondary-foreground: oklch(0.96 0.002 264);
+  --muted: oklch(0.22 0.008 264);
+  --muted-foreground: oklch(0.66 0.01 264);
+  --accent: oklch(0.26 0.03 150);
+  --accent-foreground: oklch(0.85 0.12 150);
+
   --destructive: oklch(0.62 0.21 25);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 12%);
+  --border: oklch(1 0 0 / 11%);
+  --input: oklch(1 0 0 / 14%);
   --ring: oklch(0.72 0.19 150);
 }
 
@@ -65,24 +75,36 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 2px);
+  --radius-xl: calc(var(--radius) + 6px);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @layer base {
   * { border-color: var(--color-border); }
-  body { background-color: var(--color-background); color: var(--color-foreground); }
+  body {
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+    font-feature-settings: "cv11", "ss01";
+  }
+  ::selection {
+    background-color: color-mix(in oklch, var(--color-primary) 22%, transparent);
+  }
   @media (prefers-reduced-motion: no-preference) {
     html { scroll-behavior: smooth; }
   }
 }
 
-/* Hero dot-grid utility */
-.dot-grid {
-  background-image: radial-gradient(currentColor 1px, transparent 1px);
-  background-size: 16px 16px;
+/* Faint Swiss grid backdrop */
+.grid-lines {
+  background-image:
+    linear-gradient(to right, color-mix(in oklch, currentColor 100%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in oklch, currentColor 100%, transparent) 1px, transparent 1px);
+  background-size: 4.5rem 4.5rem;
 }
+
+/* Tabular figures for editorial index numbers / data */
+.tnum { font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
Complete visual redesign of the portfolio in an **editorial / Swiss** direction — oversized display type, strong grid, numbered sections, crisp corners, and a faint grid backdrop. Retains the existing **emerald green** accent, GSAP motion, next-intl (en/tr), and the EmailJS contact flow.

## Changes
- **Tokens** (`globals.css`): editorial light/dark palette, crisp radii, grid-line + tabular-figure utilities
- **Header**: editorial nav with mono section indexes (`00–04`) and animated underline
- **Section heading**: drawn-in rule with inline index number + GSAP word reveal
- **Hero**: oversized stacked wordmark, meta top bar (prompt + location), grayscale portrait, parallax + char-stagger entrance
- **About / Résumé**: grid-driven editorial layout and timeline rows
- **Portfolio → "Selected Work"**: numbered project index with cursor-following image preview (built from Magic MCP showcase), detail dialog retained
- **Contact / Footer**: large editorial CTA and editorial footer
- **OG image**: refreshed, keeps emerald accents
- **Copy**: "Selected Work" heading (en/tr)

## Verification
- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run build` ✓ (both locales prerender)

🤖 Generated with [Claude Code](https://claude.com/claude-code)