### PR TITLE
fix(portfolio): prevent work-preview rectangle flash on load

### DIFF
--- a/src/components/sections/portfolio.tsx
+++ b/src/components/sections/portfolio.tsx
@@ -46,6 +46,7 @@ export function Portfolio() {
   }
 
   function show(i: number) {
+    if (!xTo.current) return; // only on hover-capable devices where the preview is enabled
     setActive(i);
     gsap.to(preview.current, {opacity: 1, scale: 1, duration: 0.3, ease: 'power3.out'});
   }
@@ -64,7 +65,7 @@ export function Portfolio() {
         <div
           ref={preview}
           aria-hidden
-          className="pointer-events-none fixed left-0 top-0 z-40 hidden aspect-[16/10] w-[24rem] overflow-hidden border border-border bg-card shadow-2xl will-change-transform md:block"
+          className="pointer-events-none fixed left-0 top-0 z-40 hidden aspect-[16/10] w-[24rem] overflow-hidden border border-border bg-card opacity-0 shadow-2xl will-change-transform md:block"
         >
           {active !== null && (
             <Image


### PR DESCRIPTION
## Problem
On a refresh at the top of the page, an empty rectangle briefly flashed in the top-left corner.

## Cause
The floating cursor-preview `<div>` in **Selected Work** is `position: fixed; left: 0; top: 0` with a `bg-card`, border, and shadow. It rendered **fully opaque** in the initial HTML and only became invisible once GSAP's `gsap.set(..., {opacity: 0})` ran after hydration — so for one frame the bare card showed in the corner.

## Fix
- Ship the preview with `opacity-0` so it's hidden from the very first paint (before any JS).
- Guard `show()` to only run on hover-capable devices where the preview is actually enabled (also avoids a stuck rectangle under reduced-motion).

## Verification
- `npm run typecheck` ✓
- Rendered HTML now includes `opacity-0` on the preview element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)